### PR TITLE
Add underlying type to StatusCode enum

### DIFF
--- a/include/grpcpp/support/status_code_enum.h
+++ b/include/grpcpp/support/status_code_enum.h
@@ -23,7 +23,7 @@
 
 namespace grpc {
 
-enum StatusCode {
+enum StatusCode : int {
   /// Not an error; returned on success.
   OK = 0,
 


### PR DESCRIPTION
Motivation: there are some services and organizations that use their custom status codes, e.g
1. https://github.com/openfga/api/blob/f9709139a3693f6624efda12a001e242c5d506b6/openfga/v1/errors_ignore.proto#L22

It seems that this is supported at least in golang. In c++, even though returning this code technically works, it is considered UB because enum StatusCode has no underlying type specified and thus some values fall out of range.

This change sets underlying type for StatusCode.




<!--

If you know who should review your pull request, please assign it to that
person, otherwise the pull request would get assigned randomly.

If your pull request is for a specific language, please add the appropriate
lang label.

-->

